### PR TITLE
Soil fertility255fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Mi Flora Care",
   "name": "homebridge-mi-flora-care",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "This is a homebridge plugin for the Xiaomi Mi Flora / Xiaomi Flower Care devices.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/miFloraAccessory.ts
+++ b/src/miFloraAccessory.ts
@@ -70,7 +70,7 @@ export class MiFloraCareAccessory implements AccessoryPlugin {
 
       // MiFLora scan input
       this._opts = {
-        duration: 15000,
+        duration: 30000, // previous value was 15sec. 
         ignoreUnknown: true,
         addresses: [this.deviceId.toLowerCase()],
       };

--- a/src/plantSensorService.ts
+++ b/src/plantSensorService.ts
@@ -39,7 +39,7 @@ export const plantSensorService = (api: API): typeof PlantSensor => {
 
         constructor() {
           super('SoilFertility', SoilFertility.UUID, {
-            format: Formats.UINT8,
+            format: Formats.UINT16,
             maxValue: 10000,
             minValue: 0,
             minStep: 1,


### PR DESCRIPTION
Running the plugin, I noticed that the SoilFertility sensor cannot contains values greater than 255. I changed the int format to allow values greater than 255. I tested the plugin and I can see a value of 277 for my sensor.